### PR TITLE
Add vitest configuration and basic tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
 		"prepack": "svelte-kit sync && svelte-package && publint",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"format": "prettier --write .",
-		"lint": "prettier --check . && eslint ."
-	},
+                "format": "prettier --write .",
+                "lint": "prettier --check . && eslint .",
+                "test": "vitest"
+        },
 	"keywords": [],
 	"author": "",
 	"license": "",
@@ -65,8 +66,12 @@
 		"typescript": "^5.0.0",
 		"typescript-eslint": "^8.20.0",
 		"vite": "^6.2.6",
-		"vite-plugin-static-copy": "^2.3.1"
-	},
+        "vite-plugin-static-copy": "^2.3.1"
+                ,"vitest": "^1.5.3"
+                ,"@testing-library/svelte": "^4.2.1"
+                ,"@testing-library/user-event": "^14.4.3"
+                ,"jsdom": "^24.0.0"
+        },
 	"peerDependencies": {
 		"svelte": "^5.0.0"
 	}

--- a/src/lib/components/__tests__/Game.test.ts
+++ b/src/lib/components/__tests__/Game.test.ts
@@ -1,0 +1,107 @@
+import { render, fireEvent } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import Game from '../Game.svelte';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- Mock GameState ---------------------------------------------------------
+const instances: any[] = [];
+
+class MockGameState {
+  score = 0;
+  gameOver = false;
+  currentFruitIndex = 0;
+  nextFruitIndex = 1;
+  fruitsState: any[] = [];
+  mergeEffects: any[] = [];
+  dropCount = 0;
+  audioManager = { isMuted: false, toggleMute: vi.fn() };
+  dropFruit = vi.fn((index: number, x: number, y: number) => {
+    this.fruitsState.push({ x, y, rotation: 0, fruitIndex: index });
+    this.dropCount++;
+  });
+  restartGame = vi.fn(() => {
+    this.gameOver = false;
+    this.fruitsState = [];
+    this.dropCount = 0;
+  });
+  destroy = vi.fn();
+  constructor() {
+    instances.push(this);
+  }
+}
+
+vi.mock('../../stores/game.svelte.js', () => ({ GameState: MockGameState, instances }));
+
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  instances.length = 0;
+});
+
+describe('Game component', () => {
+  it('initializes with introduction modal open', () => {
+    const { getByText } = render(Game);
+    expect(getByText('Subak Game')).toBeInTheDocument();
+    expect(instances.length).toBe(1);
+    expect(instances[0].score).toBe(0);
+  });
+
+  it('moves drop line and preview fruit with pointer', async () => {
+    const { container, getByRole } = render(Game);
+    // close introduction modal
+    await fireEvent.click(getByRole('button', { name: /resume game/i }));
+    await tick();
+
+    const area = container.querySelector('.gameplay-area') as HTMLElement;
+    Object.defineProperty(area, 'getBoundingClientRect', {
+      value: () => ({ left: 0, top: 0, width: 600, height: 900, right: 600, bottom: 900 })
+    });
+
+    await fireEvent.mouseMove(area, { clientX: 150, clientY: 100 });
+
+    const dropLine = container.querySelector('.drop-line') as HTMLElement;
+    const preview = container.querySelector('.preview-fruit') as HTMLElement;
+    expect(dropLine.style.translate).toContain('149px');
+    expect(preview.style.translate).toContain('150px');
+  });
+
+  it('drops a fruit on click', async () => {
+    const { container, getByRole } = render(Game);
+    await fireEvent.click(getByRole('button', { name: /resume game/i }));
+    await tick();
+
+    const area = container.querySelector('.gameplay-area') as HTMLElement;
+    Object.defineProperty(area, 'getBoundingClientRect', {
+      value: () => ({ left: 0, top: 0, width: 600, height: 900, right: 600, bottom: 900 })
+    });
+
+    await fireEvent.pointerUp(area);
+    expect(instances[0].dropFruit).toHaveBeenCalled();
+    expect(instances[0].fruitsState.length).toBe(1);
+  });
+
+  it('handles modal visibility and game restart', async () => {
+    const { getByRole, queryByText } = render(Game);
+
+    // intro visible
+    expect(getByRole('button', { name: /resume game/i })).toBeInTheDocument();
+
+    // close intro
+    await fireEvent.click(getByRole('button', { name: /resume game/i }));
+    await tick();
+    expect(queryByText('Subak Game')).not.toBeInTheDocument();
+
+    // open intro via header button
+    await fireEvent.click(getByRole('button', { name: /about/i }));
+    expect(getByRole('button', { name: /resume game/i })).toBeInTheDocument();
+
+    // simulate game over and ensure game over modal shows
+    instances[0].gameOver = true;
+    await tick();
+    expect(getByRole('heading', { name: /thanks for playing/i })).toBeInTheDocument();
+
+    // restart game
+    await fireEvent.click(getByRole('button', { name: /start new game/i }));
+    expect(instances[0].restartGame).toHaveBeenCalled();
+  });
+});

--- a/src/lib/stores/__tests__/gameState.test.ts
+++ b/src/lib/stores/__tests__/gameState.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GameState } from '../game.svelte.js';
+import { FRUITS } from '../../constants';
+
+// Stub physics related methods before constructing GameState
+vi.spyOn(GameState.prototype as any, 'initPhysics').mockImplementation(async function(this: any){
+  this.physicsWorld = {
+    integrationParameters: { dt: 1/60 },
+    removeRigidBody: vi.fn()
+  };
+  this.eventQueue = { drainCollisionEvents: vi.fn() };
+});
+vi.spyOn(GameState.prototype as any, 'update').mockImplementation(() => {});
+vi.spyOn(GameState.prototype as any, 'addFruit').mockImplementation(function(this: any, fruitIndex: number, x: number, y: number){
+  const fruit = {
+    fruitIndex,
+    radius: FRUITS[fruitIndex].radius,
+    points: FRUITS[fruitIndex].points,
+    body: {
+      handle: ++(this._handle || (this._handle = 0)),
+      isValid: () => true,
+      translation: () => ({ x, y }),
+      rotation: () => 0,
+      linvel: () => ({ x:0, y:0 })
+    },
+    collider: { handle: (this._handle || 0) },
+    destroy: vi.fn(),
+    physicsWorld: this.physicsWorld
+  };
+  this.fruits.push(fruit);
+  this.colliderMap.set(fruit.body.handle, fruit);
+  return fruit;
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GameState merging', () => {
+  it('merges two fruits of the same type', () => {
+    const state = new GameState({});
+    // add two fruits of type 0
+    const a = state.addFruit(0, 0.2, 0.2);
+    const b = state.addFruit(0, 0.25, 0.2);
+    const initialCount = state.fruits.length;
+    state.mergeFruits(a, b);
+    expect(state.fruits.length).toBe(initialCount - 1);
+    expect(state.fruits[0].fruitIndex).toBe(1);
+    expect(state.score).toBe(FRUITS[1].points);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [svelte({ preprocess: vitePreprocess() })],
+  test: {
+    environment: 'jsdom'
+  }
+});


### PR DESCRIPTION
## Summary
- set up vitest with jsdom
- add testing dependencies and npm test script
- create tests for `Game.svelte` covering pointer movement, dropping fruit, modal behavior, and restart
- add unit test for `GameState` merging logic

## Testing
- `npm test` *(fails: vitest: not found)*