### PR TITLE
Fix failing tests with jsdom mocks

### DIFF
--- a/src/lib/stores/__tests__/gameState.test.ts
+++ b/src/lib/stores/__tests__/gameState.test.ts
@@ -3,21 +3,22 @@ import { GameState } from '../game.svelte.js';
 import { FRUITS } from '../../constants';
 
 // Stub physics related methods before constructing GameState
-vi.spyOn(GameState.prototype as any, 'initPhysics').mockImplementation(async function(this: any){
+const proto: any = GameState.prototype;
+vi.spyOn(proto, 'initPhysics').mockImplementation(async function(this: any){
   this.physicsWorld = {
     integrationParameters: { dt: 1/60 },
     removeRigidBody: vi.fn()
   };
   this.eventQueue = { drainCollisionEvents: vi.fn() };
 });
-vi.spyOn(GameState.prototype as any, 'update').mockImplementation(() => {});
-vi.spyOn(GameState.prototype as any, 'addFruit').mockImplementation(function(this: any, fruitIndex: number, x: number, y: number){
+vi.spyOn(proto, 'update').mockImplementation(() => {});
+vi.spyOn(proto, 'addFruit').mockImplementation(function(this: any, fruitIndex: number, x: number, y: number){
   const fruit = {
     fruitIndex,
     radius: FRUITS[fruitIndex].radius,
     points: FRUITS[fruitIndex].points,
     body: {
-      handle: ++(this._handle || (this._handle = 0)),
+      handle: (this._handle = (this._handle ?? 0) + 1),
       isValid: () => true,
       translation: () => ({ x, y }),
       rotation: () => 0,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,20 @@
-import { svelte } from '@sveltejs/vite-plugin-svelte';
-import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import { svelte, vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  plugins: [svelte({ preprocess: vitePreprocess() })],
+  plugins: [
+    svelte({
+      preprocess: vitePreprocess({ style: false }),
+      configFile: false,
+      compilerOptions: { generate: 'dom' }
+    })
+  ],
+  resolve: {
+    mainFields: ['browser', 'module', 'main'],
+    conditions: ['browser']
+  },
   test: {
-    environment: 'jsdom'
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts']
   }
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,36 @@
+import { vi, beforeAll } from 'vitest';
+
+beforeAll(() => {
+  if (typeof window !== 'undefined' && !('matchMedia' in window)) {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn()
+      }))
+    });
+  }
+  if (!HTMLElement.prototype.animate) {
+    // minimal Web Animations API mock
+    HTMLElement.prototype.animate = () => ({ finished: Promise.resolve(), cancel: () => {} });
+  }
+});
+
+vi.mock('howler', () => {
+  return {
+    Howl: vi.fn(() => ({ play: vi.fn(), stop: vi.fn() })),
+    Howler: { ctx: { state: 'running' }, _muted: false }
+  };
+});
+
+vi.mock('svelte/motion', () => ({
+  Tween: {
+    of: (getter: () => number) => ({ current: getter() })
+  }
+}));


### PR DESCRIPTION
## Summary
- disable CSS preprocessing for tests
- polyfill DOM APIs in `vitest.setup.ts`
- mock modules in component tests
- fix GameState test stubs
- adjust component tests for new markup

## Testing
- `npm test --silent`