### PR TITLE
Add DB mocks and leaderboard tests

### DIFF
--- a/src/lib/components/__tests__/Leaderboard.test.ts
+++ b/src/lib/components/__tests__/Leaderboard.test.ts
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import Leaderboard from '../Leaderboard.svelte';
+
+const sampleScores = [
+  { id: 1, score: 1200, date: new Date('2024-01-01') },
+  { id: 2, score: 800, date: new Date('2024-01-02') }
+];
+
+describe('Leaderboard component', () => {
+  it('renders provided scores', () => {
+    const { container } = render(Leaderboard, { props: { scores: sampleScores } });
+    const rows = container.querySelectorAll('tbody tr');
+    expect(rows.length).toBe(sampleScores.length);
+    const firstRow = rows[0] as HTMLElement;
+    expect(firstRow.querySelector('.rank')?.textContent).toBe('1');
+    expect(firstRow.querySelector('.score')?.textContent).toContain('1,200');
+  });
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -34,3 +34,20 @@ vi.mock('svelte/motion', () => ({
     of: (getter: () => number) => ({ current: getter() })
   }
 }));
+
+// --- Mock database access ---------------------------------------------------
+const mockScores: { id: number; score: number; date: Date }[] = [];
+
+vi.mock('./src/lib/stores/db', () => {
+  return {
+    saveScore: vi.fn(async (score: number) => {
+      mockScores.push({ id: mockScores.length + 1, score, date: new Date() });
+    }),
+    getHighScores: vi.fn(async () => {
+      return [...mockScores]
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 10);
+    }),
+    __mockScores: mockScores
+  };
+});


### PR DESCRIPTION
## Summary
- mock `db` store globally in test setup to silence Dexie errors
- add component test for `Leaderboard`

## Testing
- `npx vitest run`
