### PR TITLE
Fix mouse back/forward buttons drop fruit

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,9 +10,10 @@ export default tsEslint.config(
 	js.configs.recommended,
 	...tsEslint.configs.recommended,
 	...svelteEslint.configs.prettier,
-	...prettierEslint.configs.recommended,
+	// Apply Prettier's formatting rules
+	prettierEslint,
 	{
-		ignores: ['dist/**', 'docs/**']
+		ignores: ['dist/**', 'docs/**', '.svelte-kit/**']
 	},
 	{
 		languageOptions: {

--- a/src/lib/components/Game.svelte
+++ b/src/lib/components/Game.svelte
@@ -109,7 +109,13 @@
 	// --- Event Handlers ---
 
 	// Handle clicking/tapping to drop a fruit
-	function handleClick(): void {
+	function handleClick(event: PointerEvent): void {
+		// Only react to primary pointer button (typically left click).
+		// If the button property is undefined (e.g. in some test
+		// environments), treat it as a primary button click. This keeps
+		// browser navigation buttons functional.
+		if (event.button !== undefined && event.button !== 0) return;
+
 		dropCurrentFruit();
 	}
 

--- a/src/lib/components/IntroductionModal.svelte
+++ b/src/lib/components/IntroductionModal.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { getContext } from 'svelte';
-
 	import Modal from './Modal.svelte';
 
 	import { getHighScores } from '../stores/db';

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { quadOut } from 'svelte/easing';
 	import { fade, scale } from 'svelte/transition';
-	import { onDestroy } from 'svelte';
 
 	// --- Props ---
 	// `open`: Controls the visibility of the modal (bindable)

--- a/src/lib/components/__tests__/Game.test.ts
+++ b/src/lib/components/__tests__/Game.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { vi } from 'vitest';
 
 import { render, fireEvent } from '@testing-library/svelte';
@@ -11,104 +12,106 @@ import * as gameStateModule from '../../stores/game.svelte.js';
 const instances: any[] = [];
 
 class MockGameState {
-  score = 0;
-  gameOver = false;
-  currentFruitIndex = 0;
-  nextFruitIndex = 1;
-  fruitsState: any[] = [];
-  mergeEffects: any[] = [];
-  dropCount = 0;
-  audioManager = { isMuted: false, toggleMute: vi.fn() };
-  dropFruit = vi.fn((index: number, x: number, y: number) => {
-    this.fruitsState.push({ x, y, rotation: 0, fruitIndex: index });
-    this.dropCount++;
-  });
-  restartGame = vi.fn(() => {
-    this.gameOver = false;
-    this.fruitsState = [];
-    this.dropCount = 0;
-  });
-  destroy = vi.fn();
-  constructor() {
-    instances.push(this);
-  }
+	score = 0;
+	gameOver = false;
+	currentFruitIndex = 0;
+	nextFruitIndex = 1;
+	fruitsState: any[] = [];
+	mergeEffects: any[] = [];
+	dropCount = 0;
+	audioManager = { isMuted: false, toggleMute: vi.fn() };
+	dropFruit = vi.fn((index: number, x: number, y: number) => {
+		this.fruitsState.push({ x, y, rotation: 0, fruitIndex: index });
+		this.dropCount++;
+	});
+	restartGame = vi.fn(() => {
+		this.gameOver = false;
+		this.fruitsState = [];
+		this.dropCount = 0;
+	});
+	destroy = vi.fn();
+	constructor() {
+		instances.push(this);
+	}
 }
 
 vi.mock('../../stores/game.svelte.js', () => ({ GameState: vi.fn() }));
 
 // Replace the mocked constructor with our implementation
-(gameStateModule as any).GameState.mockImplementation((...args: any[]) => new MockGameState(...args));
+(gameStateModule as any).GameState.mockImplementation(
+	(...args: any[]) => new MockGameState(...args)
+);
 
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-  instances.length = 0;
+	instances.length = 0;
 });
 
 describe('Game component', () => {
-  it('initializes with introduction modal open', () => {
-    const { getAllByText } = render(Game);
-    expect(getAllByText('Subak Game').length).toBeGreaterThan(0);
-    expect(instances.length).toBe(1);
-    expect(instances[0].score).toBe(0);
-  });
+	it('initializes with introduction modal open', () => {
+		const { getAllByText } = render(Game);
+		expect(getAllByText('Subak Game').length).toBeGreaterThan(0);
+		expect(instances.length).toBe(1);
+		expect(instances[0].score).toBe(0);
+	});
 
-  it('moves drop line and preview fruit with pointer', async () => {
-    const { container, getAllByRole } = render(Game);
-    // close introduction modal
-    await fireEvent.click(getAllByRole('button', { name: /resume game/i })[0]);
-    await tick();
+	it('moves drop line and preview fruit with pointer', async () => {
+		const { container, getAllByRole } = render(Game);
+		// close introduction modal
+		await fireEvent.click(getAllByRole('button', { name: /resume game/i })[0]);
+		await tick();
 
-    const area = container.querySelector('.gameplay-area') as HTMLElement;
-    Object.defineProperty(area, 'getBoundingClientRect', {
-      value: () => ({ left: 0, top: 0, width: 600, height: 900, right: 600, bottom: 900 })
-    });
+		const area = container.querySelector('.gameplay-area') as HTMLElement;
+		Object.defineProperty(area, 'getBoundingClientRect', {
+			value: () => ({ left: 0, top: 0, width: 600, height: 900, right: 600, bottom: 900 })
+		});
 
-    await fireEvent.mouseMove(area, { clientX: 150, clientY: 100 });
+		await fireEvent.mouseMove(area, { clientX: 150, clientY: 100 });
 
-    const dropLine = container.querySelector('.drop-line') as HTMLElement;
-    const preview = container.querySelector('.preview-fruit') as HTMLElement;
-    expect(dropLine.style.translate).toContain('149px');
-    expect(preview.style.translate).toContain('150px');
-  });
+		const dropLine = container.querySelector('.drop-line') as HTMLElement;
+		const preview = container.querySelector('.preview-fruit') as HTMLElement;
+		expect(dropLine.style.translate).toContain('149px');
+		expect(preview.style.translate).toContain('150px');
+	});
 
-  it('drops a fruit on click', async () => {
-    const { container, getAllByRole } = render(Game);
-    await fireEvent.click(getAllByRole('button', { name: /resume game/i })[0]);
-    await tick();
+	it('drops a fruit on click', async () => {
+		const { container, getAllByRole } = render(Game);
+		await fireEvent.click(getAllByRole('button', { name: /resume game/i })[0]);
+		await tick();
 
-    const area = container.querySelector('.gameplay-area') as HTMLElement;
-    Object.defineProperty(area, 'getBoundingClientRect', {
-      value: () => ({ left: 0, top: 0, width: 600, height: 900, right: 600, bottom: 900 })
-    });
+		const area = container.querySelector('.gameplay-area') as HTMLElement;
+		Object.defineProperty(area, 'getBoundingClientRect', {
+			value: () => ({ left: 0, top: 0, width: 600, height: 900, right: 600, bottom: 900 })
+		});
 
-    await fireEvent.pointerUp(area);
-    expect(instances[0].dropFruit).toHaveBeenCalled();
-    expect(instances[0].fruitsState.length).toBe(1);
-  });
+		await fireEvent.pointerUp(area, { button: 0 });
+		expect(instances[0].dropFruit).toHaveBeenCalled();
+		expect(instances[0].fruitsState.length).toBe(1);
+	});
 
-  it('handles modal visibility and game restart', async () => {
-    const { getAllByRole } = render(Game);
+	it('handles modal visibility and game restart', async () => {
+		const { getAllByRole } = render(Game);
 
-    // intro visible
-    let resumeButtons = getAllByRole('button', { name: /resume game/i });
-    expect(resumeButtons.length).toBeGreaterThan(0);
+		// intro visible
+		let resumeButtons = getAllByRole('button', { name: /resume game/i });
+		expect(resumeButtons.length).toBeGreaterThan(0);
 
-    // close intro
-    await fireEvent.click(resumeButtons[0]);
-    await tick();
+		// close intro
+		await fireEvent.click(resumeButtons[0]);
+		await tick();
 
-    // open intro via header button
-    await fireEvent.click(getAllByRole('button', { name: /about/i })[0]);
-    resumeButtons = getAllByRole('button', { name: /resume game/i });
-    expect(resumeButtons.length).toBeGreaterThan(0);
+		// open intro via header button
+		await fireEvent.click(getAllByRole('button', { name: /about/i })[0]);
+		resumeButtons = getAllByRole('button', { name: /resume game/i });
+		expect(resumeButtons.length).toBeGreaterThan(0);
 
-    // simulate game over and ensure game over modal shows
-    instances[0].gameOver = true;
-    await tick();
+		// simulate game over and ensure game over modal shows
+		instances[0].gameOver = true;
+		await tick();
 
-    // restart game
-    instances[0].restartGame();
-    expect(instances[0].restartGame).toHaveBeenCalled();
-  });
+		// restart game
+		instances[0].restartGame();
+		expect(instances[0].restartGame).toHaveBeenCalled();
+	});
 });

--- a/src/lib/components/__tests__/Leaderboard.test.ts
+++ b/src/lib/components/__tests__/Leaderboard.test.ts
@@ -3,17 +3,17 @@ import { describe, it, expect } from 'vitest';
 import Leaderboard from '../Leaderboard.svelte';
 
 const sampleScores = [
-  { id: 1, score: 1200, date: new Date('2024-01-01') },
-  { id: 2, score: 800, date: new Date('2024-01-02') }
+	{ id: 1, score: 1200, date: new Date('2024-01-01') },
+	{ id: 2, score: 800, date: new Date('2024-01-02') }
 ];
 
 describe('Leaderboard component', () => {
-  it('renders provided scores', () => {
-    const { container } = render(Leaderboard, { props: { scores: sampleScores } });
-    const rows = container.querySelectorAll('tbody tr');
-    expect(rows.length).toBe(sampleScores.length);
-    const firstRow = rows[0] as HTMLElement;
-    expect(firstRow.querySelector('.rank')?.textContent).toBe('1');
-    expect(firstRow.querySelector('.score')?.textContent).toContain('1,200');
-  });
+	it('renders provided scores', () => {
+		const { container } = render(Leaderboard, { props: { scores: sampleScores } });
+		const rows = container.querySelectorAll('tbody tr');
+		expect(rows.length).toBe(sampleScores.length);
+		const firstRow = rows[0] as HTMLElement;
+		expect(firstRow.querySelector('.rank')?.textContent).toBe('1');
+		expect(firstRow.querySelector('.score')?.textContent).toContain('1,200');
+	});
 });

--- a/src/lib/stores/__tests__/gameState.test.ts
+++ b/src/lib/stores/__tests__/gameState.test.ts
@@ -1,52 +1,58 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GameState } from '../game.svelte.js';
 import { FRUITS } from '../../constants';
 
 // Stub physics related methods before constructing GameState
 const proto: any = GameState.prototype;
-vi.spyOn(proto, 'initPhysics').mockImplementation(async function(this: any){
-  this.physicsWorld = {
-    integrationParameters: { dt: 1/60 },
-    removeRigidBody: vi.fn()
-  };
-  this.eventQueue = { drainCollisionEvents: vi.fn() };
+vi.spyOn(proto, 'initPhysics').mockImplementation(async function (this: any) {
+	this.physicsWorld = {
+		integrationParameters: { dt: 1 / 60 },
+		removeRigidBody: vi.fn()
+	};
+	this.eventQueue = { drainCollisionEvents: vi.fn() };
 });
 vi.spyOn(proto, 'update').mockImplementation(() => {});
-vi.spyOn(proto, 'addFruit').mockImplementation(function(this: any, fruitIndex: number, x: number, y: number){
-  const fruit = {
-    fruitIndex,
-    radius: FRUITS[fruitIndex].radius,
-    points: FRUITS[fruitIndex].points,
-    body: {
-      handle: (this._handle = (this._handle ?? 0) + 1),
-      isValid: () => true,
-      translation: () => ({ x, y }),
-      rotation: () => 0,
-      linvel: () => ({ x:0, y:0 })
-    },
-    collider: { handle: (this._handle || 0) },
-    destroy: vi.fn(),
-    physicsWorld: this.physicsWorld
-  };
-  this.fruits.push(fruit);
-  this.colliderMap.set(fruit.body.handle, fruit);
-  return fruit;
+vi.spyOn(proto, 'addFruit').mockImplementation(function (
+	this: any,
+	fruitIndex: number,
+	x: number,
+	y: number
+) {
+	const fruit = {
+		fruitIndex,
+		radius: FRUITS[fruitIndex].radius,
+		points: FRUITS[fruitIndex].points,
+		body: {
+			handle: (this._handle = (this._handle ?? 0) + 1),
+			isValid: () => true,
+			translation: () => ({ x, y }),
+			rotation: () => 0,
+			linvel: () => ({ x: 0, y: 0 })
+		},
+		collider: { handle: this._handle || 0 },
+		destroy: vi.fn(),
+		physicsWorld: this.physicsWorld
+	};
+	this.fruits.push(fruit);
+	this.colliderMap.set(fruit.body.handle, fruit);
+	return fruit;
 });
 
 beforeEach(() => {
-  vi.clearAllMocks();
+	vi.clearAllMocks();
 });
 
 describe('GameState merging', () => {
-  it('merges two fruits of the same type', () => {
-    const state = new GameState({});
-    // add two fruits of type 0
-    const a = state.addFruit(0, 0.2, 0.2);
-    const b = state.addFruit(0, 0.25, 0.2);
-    const initialCount = state.fruits.length;
-    state.mergeFruits(a, b);
-    expect(state.fruits.length).toBe(initialCount - 1);
-    expect(state.fruits[0].fruitIndex).toBe(1);
-    expect(state.score).toBe(FRUITS[1].points);
-  });
+	it('merges two fruits of the same type', () => {
+		const state = new GameState({});
+		// add two fruits of type 0
+		const a = state.addFruit(0, 0.2, 0.2);
+		const b = state.addFruit(0, 0.25, 0.2);
+		const initialCount = state.fruits.length;
+		state.mergeFruits(a, b);
+		expect(state.fruits.length).toBe(initialCount - 1);
+		expect(state.fruits[0].fruitIndex).toBe(1);
+		expect(state.score).toBe(FRUITS[1].points);
+	});
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,19 +2,19 @@ import { svelte, vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  plugins: [
-    svelte({
-      preprocess: vitePreprocess({ style: false }),
-      configFile: false,
-      compilerOptions: { generate: 'dom' }
-    })
-  ],
-  resolve: {
-    mainFields: ['browser', 'module', 'main'],
-    conditions: ['browser']
-  },
-  test: {
-    environment: 'jsdom',
-    setupFiles: ['./vitest.setup.ts']
-  }
+	plugins: [
+		svelte({
+			preprocess: vitePreprocess({ style: false }),
+			configFile: false,
+			compilerOptions: { generate: 'dom' }
+		})
+	],
+	resolve: {
+		mainFields: ['browser', 'module', 'main'],
+		conditions: ['browser']
+	},
+	test: {
+		environment: 'jsdom',
+		setupFiles: ['./vitest.setup.ts']
+	}
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,53 +1,51 @@
 import { vi, beforeAll } from 'vitest';
 
 beforeAll(() => {
-  if (typeof window !== 'undefined' && !('matchMedia' in window)) {
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: vi.fn().mockImplementation((query: string) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-        addListener: vi.fn(),
-        removeListener: vi.fn(),
-        dispatchEvent: vi.fn()
-      }))
-    });
-  }
-  if (!HTMLElement.prototype.animate) {
-    // minimal Web Animations API mock
-    HTMLElement.prototype.animate = () => ({ finished: Promise.resolve(), cancel: () => {} });
-  }
+	if (typeof window !== 'undefined' && !('matchMedia' in window)) {
+		Object.defineProperty(window, 'matchMedia', {
+			writable: true,
+			value: vi.fn().mockImplementation((query: string) => ({
+				matches: false,
+				media: query,
+				onchange: null,
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+				addListener: vi.fn(),
+				removeListener: vi.fn(),
+				dispatchEvent: vi.fn()
+			}))
+		});
+	}
+	if (!HTMLElement.prototype.animate) {
+		// minimal Web Animations API mock
+		HTMLElement.prototype.animate = () => ({ finished: Promise.resolve(), cancel: () => {} });
+	}
 });
 
 vi.mock('howler', () => {
-  return {
-    Howl: vi.fn(() => ({ play: vi.fn(), stop: vi.fn() })),
-    Howler: { ctx: { state: 'running' }, _muted: false }
-  };
+	return {
+		Howl: vi.fn(() => ({ play: vi.fn(), stop: vi.fn() })),
+		Howler: { ctx: { state: 'running' }, _muted: false }
+	};
 });
 
 vi.mock('svelte/motion', () => ({
-  Tween: {
-    of: (getter: () => number) => ({ current: getter() })
-  }
+	Tween: {
+		of: (getter: () => number) => ({ current: getter() })
+	}
 }));
 
 // --- Mock database access ---------------------------------------------------
 const mockScores: { id: number; score: number; date: Date }[] = [];
 
 vi.mock('./src/lib/stores/db', () => {
-  return {
-    saveScore: vi.fn(async (score: number) => {
-      mockScores.push({ id: mockScores.length + 1, score, date: new Date() });
-    }),
-    getHighScores: vi.fn(async () => {
-      return [...mockScores]
-        .sort((a, b) => b.score - a.score)
-        .slice(0, 10);
-    }),
-    __mockScores: mockScores
-  };
+	return {
+		saveScore: vi.fn(async (score: number) => {
+			mockScores.push({ id: mockScores.length + 1, score, date: new Date() });
+		}),
+		getHighScores: vi.fn(async () => {
+			return [...mockScores].sort((a, b) => b.score - a.score).slice(0, 10);
+		}),
+		__mockScores: mockScores
+	};
 });


### PR DESCRIPTION
## Summary
- ignore non-primary mouse buttons when dropping fruit
- update tests to send pointer events with primary button
- remove unused imports so ESLint passes
- fix ESLint config to use Prettier flat config and ignore `.svelte-kit`
- format repo with Prettier

## Testing
- `npx vitest run`
- `npm run lint`
