### PR TITLE
Fix: Ensure correct fruit rendering using unique keys

### DIFF
--- a/src/lib/components/Game.svelte
+++ b/src/lib/components/Game.svelte
@@ -200,7 +200,7 @@
 				<!-- Rendered fruits - Use a unique identifier if available, otherwise index -->
 				<!-- Assuming FruitState doesn't have a stable ID, index might be necessary -->
 				<!-- If FruitState *does* get an ID (e.g., collider handle), use fruit.id -->
-				{#each gameState.fruitsState as fruitState, i (i)}
+				{#each gameState.fruitsState as fruitState (fruitState.id)}
 					{@const fruit = FRUITS[fruitState.fruitIndex]}
 					<GameEntity
 						x={fruitState.x}

--- a/src/lib/components/__tests__/Game.test.ts
+++ b/src/lib/components/__tests__/Game.test.ts
@@ -46,6 +46,21 @@ vi.mock('../../stores/game.svelte.js', () => ({ GameState: vi.fn() }));
 	(...args: any[]) => new MockGameState(...args)
 );
 
+// Mock FRUITS constant
+const MOCK_FRUITS = [
+	{ id: 0, name: 'FruitA', radius: 0.1, points: 10, image: 'images/fruitA.webp', color: 'red' },
+	{ id: 1, name: 'FruitB', radius: 0.12, points: 20, image: 'images/fruitB.webp', color: 'yellow' },
+	{ id: 2, name: 'FruitC', radius: 0.15, points: 30, image: 'images/fruitC.webp', color: 'orange' }
+];
+
+vi.mock('../../constants', async () => {
+	const actual = await vi.importActual('../../constants');
+	return {
+		...(actual as any),
+		FRUITS: MOCK_FRUITS
+	};
+});
+
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
@@ -117,5 +132,57 @@ describe('Game component', () => {
 		// restart game
 		instances[0].restartGame();
 		expect(instances[0].restartGame).toHaveBeenCalled();
+	});
+
+	it('maintains correct fruit images after state changes (merges/removals)', async () => {
+		const { container, getAllByRole, debug } = render(Game);
+
+		// Start the game by clicking the start button in the modal
+		const startGameButton = getAllByRole('button', { name: /start game/i })[0];
+		await fireEvent.click(startGameButton);
+		await tick(); // Wait for game to initialize and modal to close
+
+		const mockGameState = instances[0] as MockGameState;
+		expect(mockGameState).toBeTruthy();
+
+		// Simulate adding initial fruits: FruitA, FruitB, FruitA
+		// Ensure IDs are unique for keying
+		mockGameState.fruitsState = [
+			{ id: 1, x: 100, y: 100, rotation: 0, fruitIndex: 0 }, // FruitA
+			{ id: 2, x: 200, y: 100, rotation: 0, fruitIndex: 1 }, // FruitB
+			{ id: 3, x: 300, y: 100, rotation: 0, fruitIndex: 0 }  // FruitA
+		];
+		mockGameState.setStatus('playing'); // Ensure game is in a state that renders fruits
+		await tick(); // Allow Svelte to render the fruits
+
+		let fruitImages = container.querySelectorAll('.fruit-entity img') as NodeListOf<HTMLImageElement>;
+		expect(fruitImages.length).toBe(3);
+		// Note: getAttribute('src') might return the full URL. We check for endsWith.
+		expect(fruitImages[0].getAttribute('src')).toContain(MOCK_FRUITS[0].image); // FruitA
+		expect(fruitImages[1].getAttribute('src')).toContain(MOCK_FRUITS[1].image); // FruitB
+		expect(fruitImages[2].getAttribute('src')).toContain(MOCK_FRUITS[0].image); // FruitA
+
+		// Simulate a "merge" or removal: remove the two FruitA's, leaving FruitB
+		// This simulates a scenario where the first and last elements are removed,
+		// testing if the keyed #each correctly preserves the middle element (FruitB).
+		mockGameState.fruitsState = [
+			mockGameState.fruitsState[1] // Keep only FruitB
+		];
+		await tick(); // Allow Svelte to re-render
+
+		fruitImages = container.querySelectorAll('.fruit-entity img') as NodeListOf<HTMLImageElement>;
+		// debug(); // Optional: to see the DOM structure if the test fails
+
+		expect(fruitImages.length).toBe(1);
+		expect(fruitImages[0].getAttribute('src')).toContain(MOCK_FRUITS[1].image); // Should still be FruitB
+
+		// Simulate adding another fruit to see if it still works
+		mockGameState.fruitsState.push({ id: 4, x: 400, y: 100, rotation: 0, fruitIndex: 2 }); // FruitC
+		await tick();
+
+		fruitImages = container.querySelectorAll('.fruit-entity img') as NodeListOf<HTMLImageElement>;
+		expect(fruitImages.length).toBe(2);
+		expect(fruitImages[0].getAttribute('src')).toContain(MOCK_FRUITS[1].image); // FruitB
+		expect(fruitImages[1].getAttribute('src')).toContain(MOCK_FRUITS[2].image); // FruitC
 	});
 });

--- a/src/lib/stores/game.svelte.ts
+++ b/src/lib/stores/game.svelte.ts
@@ -50,6 +50,7 @@ export interface MergeEffectData {
 	duration: number;
 }
 export interface FruitState {
+	id: number; // Add this line
 	x: number;
 	y: number;
 	rotation: number;
@@ -171,6 +172,7 @@ export class GameState {
 			.map((fruit) => {
 				if (!fruit.body.isValid()) return null;
 				return {
+					id: fruit.id, // Add this line
 					x: fruit.body.translation().x,
 					y: fruit.body.translation().y,
 					rotation: fruit.body.rotation(),


### PR DESCRIPTION
The fruit images in the gameplay area would sometimes briefly display the wrong fruit type. This was due to the Svelte #each block rendering fruit components using the array index as the key. When fruits were merged or removed, the array indices would change, leading Svelte to potentially reuse existing components for new fruit data, causing a temporary mismatch in display.

This commit addresses the issue by:
1.  Modifying `src/lib/stores/game.svelte.ts`:
    - The `FruitState` interface now includes an `id` field.
    - The `stepPhysics` method in `GameState` now populates this `id` from the unique `Fruit.id` when creating `fruitState` objects.
2.  Updating `src/lib/components/Game.svelte`:
    - The `#each` block that renders fruit entities now uses `fruitState.id` as the key, ensuring each component instance is uniquely tied to a specific fruit.

A new test case has been added to `src/lib/components/__tests__/Game.test.ts` to simulate fruit state changes (additions/removals) and verify that fruit images remain consistent and correct, confirming the fix.